### PR TITLE
Add account for Btc free addresses

### DIFF
--- a/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
+++ b/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
@@ -106,7 +106,10 @@ object D3TestContext {
             "btc_utxo_storage_v2",
             "notary"
         ),
-        PassiveAccountPrototype("gen_btc_pk_trigger", "notary"),
+        PassiveAccountPrototype(
+            "btc_free_addresses_storage",
+            "notary"
+        ),
         AccountPrototype("admin", "notary", listOf("admin")),
         AccountPrototype("exchanger", "notary", listOf("exchange")),
         AccountPrototype("broadcast", "notary", listOf("broadcast")),

--- a/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
+++ b/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
@@ -186,7 +186,6 @@ class IrohaTest {
 
         //Check type - keyless accounts added
         assertTrue(respBody.contains("notaries"))
-        assertTrue(respBody.contains("gen_btc_pk_trigger"))
         assertTrue(respBody.contains("btc_change_addresses"))
         //Check type - ignored accounts is not added
         assertFalse(respBody.contains("registration_service_primary"))
@@ -264,7 +263,6 @@ class IrohaTest {
             createAccountDto("btc_sign_collector", "notary"),
             createAccountDto("btc_change_addresses", "notary"),
             createAccountDto("vacuumer", "notary"),
-            createAccountDto("gen_btc_pk_trigger", "notary"),
             createAccountDto("admin", "notary"),
             createAccountDto("data_collector", "notary"),
             createAccountDto("rmq", "notary", peersCount - peersCount / 3),

--- a/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
+++ b/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
@@ -187,6 +187,7 @@ class IrohaTest {
         //Check type - keyless accounts added
         assertTrue(respBody.contains("notaries"))
         assertTrue(respBody.contains("btc_change_addresses"))
+        assertTrue(respBody.contains("btc_free_addresses_storage"))
         //Check type - ignored accounts is not added
         assertFalse(respBody.contains("registration_service_primary"))
 
@@ -262,6 +263,7 @@ class IrohaTest {
             createAccountDto("btc_withdrawal_service", "notary", peersCount - peersCount / 3),
             createAccountDto("btc_sign_collector", "notary"),
             createAccountDto("btc_change_addresses", "notary"),
+            createAccountDto("btc_free_addresses_storage", "notary"),
             createAccountDto("vacuumer", "notary"),
             createAccountDto("admin", "notary"),
             createAccountDto("data_collector", "notary"),


### PR DESCRIPTION
Just new account in the genesis block.
`gen_btc_pk_trigger` is removed because it's not needed anymore.