### PR TITLE
[DOPS-985] Move d3 docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,8 @@ pipeline {
             }
             steps {
                 script {
-                    withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                        env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19002"
+                    withCredentials([usernamePassword(credentialsId: 'bot-d3-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                        env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                         env.DOCKER_TAG = env.TAG_NAME ? env.TAG_NAME : dockerTags[env.GIT_BRANCH]
                         sh "./gradlew dockerPush"
                     }

--- a/bootstrap-project/build.gradle
+++ b/bootstrap-project/build.gradle
@@ -51,7 +51,7 @@ shadowJar.archiveName = 'app.jar'
 
 // sora-plugin configs
 soramitsu {
-    projectGroup = 'd3-deploy'
+    projectGroup = 'd3'
     docker {
         // docker tag
         tag = System.getenv("DOCKER_TAG")


### PR DESCRIPTION
# Task

[DOPS-985]: Move d3 docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-985]: https://soramitsu.atlassian.net/browse/DOPS-985